### PR TITLE
Added gulp-eslint to package.json

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -57,6 +57,7 @@
     "gulp-sourcemaps": "^1.5.1",
     "gulp-uglify": "^1.1.0",
     "gulp-util": "^3.0.4",
+    "gulp-eslint": "^2.0.0",
     "imagemin-pngquant": "^4.0.0",
     "jshint-stylish": "^1.0.1",
     "log4js": "^0.6.26",


### PR DESCRIPTION
When generating a ES6 template, gulp-eslint is missing.
